### PR TITLE
Fixed bug when cancelling screenshot for multiple screens

### DIFF
--- a/src/renderer/components/Screenshot/capture.js
+++ b/src/renderer/components/Screenshot/capture.js
@@ -54,7 +54,7 @@ export async function capture(id, title, screenshotPath) {
       err => {
         if (err) throw err
         // Alert the user that the screenshot was saved
-        const notification = new Notification('Screenshot saved', {
+        new Notification('Screenshot saved', {
           body: filePath
         })
       }
@@ -81,23 +81,27 @@ export function captureMultiple(ids) {
   dialog.showOpenDialog({
     properties: ['openFile', 'openDirectory', 'createDirectory']
   },
-  async function (filePaths) {
+  function (filePaths) {
     try {
-      // Capture each & save it
-      const captureEach = async (array) => {
-        for (const item of array) {
-          await capture(
-            item,
-            `${item}`,
-            filePaths[0]
-          )
+      if (filePaths.length > 0) {
+        // Capture each & save it
+        const captureEach = (array) => {
+          for (const item of array) {
+            capture(
+              item,
+              `${item}`,
+              filePaths[0]
+            )
+          }
         }
-      }
 
-      await captureEach(ids)
-      return filePaths[0]
+        captureEach(ids)
+        return filePaths[0]
+      } else {
+        // None selected
+      }
     } catch (err) {
-      // Nothing was selected
+      console.log(err)
     }
   }
   )

--- a/src/renderer/components/Screenshot/index.vue
+++ b/src/renderer/components/Screenshot/index.vue
@@ -30,7 +30,6 @@
 <script>
 import * as capture from "./capture.js";
 import { mapState } from "vuex";
-import store from "@/store";
 import { shell } from "electron";
 
 export default {
@@ -89,7 +88,7 @@ export default {
     },
 
     clearAllSelected() {
-      store.dispatch("selectedArtboardsEmpty");
+      this.$store.dispatch("selectedArtboardsEmpty");
     },
 
     async screenshotAll() {


### PR DESCRIPTION
If multiple screens were selected and you pressed Cancel in the dialog, it would show the file selector 2-3 more times. This fixes that.