### PR TITLE
Improved download UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reflex",
   "productName": "Reflex",
   "description": "Make responsive websites without the guesswork.",
-  "version": "0.6.5",
+  "version": "0.6.6-beta.1",
   "author": "Nick Wittwer",
   "license": "MIT",
   "main": "./dist/electron/main.js",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reflex",
   "productName": "Reflex",
   "description": "Make responsive websites without the guesswork.",
-  "version": "0.6.6-beta.1",
+  "version": "0.6.6-beta.2",
   "author": "Nick Wittwer",
   "license": "MIT",
   "main": "./dist/electron/main.js",

--- a/src/main/auto-updater.js
+++ b/src/main/auto-updater.js
@@ -22,9 +22,7 @@ export default function init(window) {
 
   win.on('did-finish-load', () => {
     if (isDev) {
-      sendStatusToWindow('Not checking for updates in dev mode')
-      sendStatusToWindow('Creating example update')
-
+      sendStatusToWindow('Not checking for updates in dev mode, triggering example instead.')
       win.send('DOWNLOAD_PROGRESS', '10')
 
       setTimeout(() => {

--- a/src/main/auto-updater.js
+++ b/src/main/auto-updater.js
@@ -12,21 +12,6 @@ const isDev = require('electron-is-dev')
 autoUpdater.logger = log
 autoUpdater.logger.transports.file.level = 'info'
 
-/**
- * ensureSafeQuitAndInstall
- * https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
- *
- * @access  public
- * @return  void
- */
-function ensureSafeQuitAndInstall() {
-  app.removeAllListeners('window-all-closed')
-  var browserWindows = BrowserWindow.getAllWindows()
-  browserWindows.forEach(function (browserWindow) {
-    browserWindow.removeAllListeners('close')
-  })
-}
-
 export default function init(window) {
   let UPDATE_AVAILABLE = null
   const win = window.webContents
@@ -88,9 +73,7 @@ export default function init(window) {
     logMessage = logMessage + ' (' + progressObj.transferred + '/' + progressObj.total + ')'
     sendStatusToWindow(logMessage)
 
-    /**
-     * Send the current progress to our IPC window
-     */
+    // Send the current progress to our IPC window
     window.webContents.send('DOWNLOAD_PROGRESS', progressObj.percent)
   })
 
@@ -117,8 +100,24 @@ export default function init(window) {
     }
   })
 
+  /**
+   * Handle errors
+   */
   autoUpdater.on('error', (err) => {
     log.info('error in auto-updater')
     sendStatusToWindow('Error in auto-updater. ' + err)
+  })
+}
+
+/**
+ * ensureSafeQuitAndInstall
+ * Make sure Electron quits properly
+ * https://github.com/electron-userland/electron-builder/issues/1604#issuecomment-372091881
+ */
+function ensureSafeQuitAndInstall() {
+  app.removeAllListeners('window-all-closed')
+  var browserWindows = BrowserWindow.getAllWindows()
+  browserWindows.forEach(function (browserWindow) {
+    browserWindow.removeAllListeners('close')
   })
 }

--- a/src/main/auto-updater.js
+++ b/src/main/auto-updater.js
@@ -1,46 +1,105 @@
 const log = require('electron-log')
 const {
+  ipcMain
+} = require('electron')
+const {
   autoUpdater
 } = require('electron-updater')
+const isDev = require('electron-is-dev')
 
 autoUpdater.logger = log
 autoUpdater.logger.transports.file.level = 'info'
 
 export default function init(window) {
-  const win = window
-
-  // Check for updates
-  sendStatusToWindow('Checking for updates...')
-  autoUpdater.checkForUpdatesAndNotify()
+  let UPDATE_AVAILABLE = null
+  const win = window.webContents
 
   function sendStatusToWindow(text) {
-    win.webContents.send('message', text)
+    win.send('message', text)
   }
+
+  win.on('did-finish-load', () => {
+    if (isDev) {
+      sendStatusToWindow('Not checking for updates in dev mode')
+      sendStatusToWindow('Creating example update')
+
+      win.send('DOWNLOAD_PROGRESS', '10')
+
+      setTimeout(() => {
+        win.send('DOWNLOAD_PROGRESS', '30')
+      }, 3000)
+
+      setTimeout(() => {
+        win.send('DOWNLOAD_PROGRESS', '60')
+      }, 5000)
+
+      setTimeout(() => {
+        win.send('DOWNLOAD_PROGRESS', '100')
+      }, 7000)
+    }
+
+    // Check for updates
+    if (!isDev) {
+      sendStatusToWindow('Checking for updates...')
+      autoUpdater.checkForUpdates()
+      // autoUpdater.checkForUpdatesAndNotify()
+    }
+  })
 
   autoUpdater.on('checking-for-update', () => {
     log.info('checking for update')
     sendStatusToWindow('Checking for update...')
   })
-  autoUpdater.on('update-available', (info) => {
-    log.info('update available')
-    sendStatusToWindow('Update available.')
-  })
+
   autoUpdater.on('update-not-available', (info) => {
     log.info('update not available')
     sendStatusToWindow('Update not available.')
+    UPDATE_AVAILABLE = false
   })
-  autoUpdater.on('error', (err) => {
-    log.info('error in auto-updater')
-    sendStatusToWindow('Error in auto-updater. ' + err)
+
+  // We can now know if there's an available update
+  autoUpdater.on('update-available', (info) => {
+    log.info('update available')
+    sendStatusToWindow('Update available.')
+    UPDATE_AVAILABLE = true
   })
+
+  // Tracking the progress
+  // (All of this is sent to the renderer)
   autoUpdater.on('download-progress', (progressObj) => {
     let logMessage = 'Download speed: ' + progressObj.bytesPerSecond
     logMessage = logMessage + ' - Downloaded ' + progressObj.percent + '%'
     logMessage = logMessage + ' (' + progressObj.transferred + '/' + progressObj.total + ')'
     sendStatusToWindow(logMessage)
+
+    /**
+     * Send the current progress to our IPC window
+     */
+    window.webContents.send('DOWNLOAD_PROGRESS', progressObj.percent)
   })
+
+  /**
+   * Downloaded!
+   */
   autoUpdater.on('update-downloaded', (info) => {
     log.info('update downloaded')
     sendStatusToWindow('Update downloaded')
+  })
+
+  autoUpdater.on('error', (err) => {
+    log.info('error in auto-updater')
+    sendStatusToWindow('Error in auto-updater. ' + err)
+  })
+
+  /**
+   * Listen for user to click on the
+   * install button --> install & restart
+   */
+  ipcMain.on('TRIGGER_INSTALL', () => {
+    if (UPDATE_AVAILABLE === true) {
+      autoUpdater.quitAndInstall()
+    } else {
+      console.log('No update available')
+    }
   })
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -29,7 +29,7 @@ if (process.env.NODE_ENV !== 'development') {
 
 let mainWindow
 const winURL = isDev
-  ? `http://localhost:9080`
+  ? 'http://localhost:9080'
   : `file://${__dirname}/index.html`
 
 async function createWindow() {
@@ -47,6 +47,12 @@ async function createWindow() {
     titleBarStyle: 'hiddenInset' // Hide the bar
   })
 
+  // Check for updates...
+  // Important to not wait for page to load
+  // just in case there was a fatal bug
+  // with their current release
+  autoUpdater(mainWindow)
+
   // Log the version
   log.info(`Version ${app.getVersion()}`)
 
@@ -55,11 +61,6 @@ async function createWindow() {
 
   // Setup the menu
   setMenu(mainWindow)
-
-  // Check for updates once page is loaded
-  mainWindow.webContents.once('did-finish-load', () => {
-    autoUpdater(mainWindow)
-  })
 
   mainWindow.on('closed', () => {
     mainWindow = null
@@ -101,23 +102,3 @@ app.on('certificate-error', (event, webContents, url, error, certificate, callba
   event.preventDefault()
   callback(list[0])
 })
-
-/**
- * Auto Updater
- *
- * Uncomment the following code below and install `electron-updater` to
- * support auto updating. Code Signing with a valid certificate is required.
- * https://simulatedgreg.gitbooks.io/electron-vue/content/en/using-electron-builder.html#auto-updating
- */
-
-/*
- import { autoUpdater } from 'electron-updater'
-
- autoUpdater.on('update-downloaded', () => {
-   autoUpdater.quitAndInstall()
- })
-
- app.on('ready', () => {
-   if (process.env.NODE_ENV === 'production') autoUpdater.checkForUpdates()
- })
-*/

--- a/src/renderer/assets/icons/download.svg
+++ b/src/renderer/assets/icons/download.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M13.5 4H10.5V13H6L12 20L18 13H13.5V4Z" fill="#333333"/>
+</svg>

--- a/src/renderer/components/ToolBar/InstallUpdateButton.vue
+++ b/src/renderer/components/ToolBar/InstallUpdateButton.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="install-button-container" v-if="progress !== null">
+    <ProgressIndicator :percentage="progress" @click="triggerInstall" />
+  </div>
+</template>
+
+<script>
+import isElectron from "is-electron";
+import { ipcRenderer } from "electron";
+import ProgressIndicator from "./ProgressIndicator";
+
+export default {
+  components: {
+    ProgressIndicator
+  },
+  data() {
+    return {
+      progress: null
+    };
+  },
+  computed: {
+    percentage() {
+      return `${this.progress}%`;
+    },
+    readyToInstallUpdate() {
+      if (this.progress && this.progress === 100) {
+        return true;
+      }
+      return false;
+    }
+  },
+  mounted() {
+    if (isElectron()) {
+      ipcRenderer.on("DOWNLOAD_PROGRESS", (event, progress) => {
+        this.progress = Number(progress);
+      });
+    }
+  },
+  methods: {
+    triggerInstall() {
+      ipcRenderer.send("TRIGGER_INSTALL");
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+.install-button-container {
+  position: relative;
+}
+</style>

--- a/src/renderer/components/ToolBar/ProgressIndicator.vue
+++ b/src/renderer/components/ToolBar/ProgressIndicator.vue
@@ -1,0 +1,129 @@
+<template>
+  <div
+    class="download-progress-indicator"
+    :title="readyToInstall ? 'Click to update' : ''"
+    v-on="readyToInstall ? { click: clickHandler } : {}"
+  >
+    <svg
+      :viewBox="`0 0 ${size} ${size}`"
+      class="circular-chart"
+      :class="{'is-complete':readyToInstall }"
+    >
+      <path
+        class="circle"
+        :d="`M${x} ${y}
+        a ${radius} ${radius} 0 0 1 0 ${diameter}
+        a ${radius} ${radius} 0 0 1 0 -${diameter}`"
+        :stroke-width="strokeWidth"
+        :stroke-dasharray="`${percentage} 100`"
+      />
+    </svg>
+    <div v-if="percentage === 100" class="download-complete">
+      <Icon name="download" color="light" class="download-icon" />
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  /**
+   * Inspired by:
+   * https://medium.com/@pppped/how-to-code-a-responsive-circular-percentage-chart-with-svg-and-css-3632f8cd7705
+   */
+  props: {
+    strokeWidth: {
+      type: Number,
+      default: 3
+    },
+    percentage: {
+      type: Number,
+      default: 30
+    }
+  },
+
+  data() {
+    return {
+      size: 36
+    };
+  },
+
+  computed: {
+    x() {
+      return this.size / 2;
+    },
+    y() {
+      return (this.size - this.diameter) / 2;
+    },
+    pi() {
+      return 3.14159;
+    },
+    radius() {
+      return 100 / (this.pi * 2);
+      //      ^ magic number
+    },
+    diameter() {
+      return this.radius * 2;
+    },
+    readyToInstall() {
+      if (this.percentage === 100) {
+        return true;
+      }
+      return false;
+    }
+  },
+  methods: {
+    clickHandler() {
+      this.$emit("click");
+    }
+  }
+};
+</script>
+
+<style lang="scss" scoped>
+@import "~@/scss/_variables";
+
+.download-progress-indicator {
+  position: relative;
+}
+
+.circular-chart {
+  display: block;
+  max-width: $gui-title-bar-height;
+  padding: 0.5rem;
+  width: 100%;
+
+  &.is-complete .circle {
+    stroke: white;
+  }
+}
+
+.circle {
+  position: relative;
+  display: block;
+  stroke: #4cc790;
+  fill: none;
+  stroke-linecap: round;
+  transition: all 0.3s ease-in-out;
+}
+
+.download-complete {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: #0fc616;
+  height: 80%;
+  width: 80%;
+  z-index: -1;
+  border-radius: 6px;
+  padding: 0.5rem;
+  box-shadow: 0 2px 2px rgba(black, 0.15);
+
+  .download-icon {
+    transform: scale(0.7)
+  }
+}
+</style>

--- a/src/renderer/components/ToolBar/index.vue
+++ b/src/renderer/components/ToolBar/index.vue
@@ -35,6 +35,7 @@
       <div class="toolbar__button-group">
       </div>
     </div>-->
+    <InstallUpdateButton/>
     <div id="draggable" @dblclick="toggleWindowMaximize"></div>
   </div>
 </template>
@@ -42,9 +43,10 @@
 <script>
 import store from "@/store";
 import { mapState } from "vuex";
-import URLInput from "./URLInput.vue";
-import SyncButton from "./SyncButton.vue";
-import HistoryControls from "./HistoryControls.vue";
+import URLInput from "@/components/ToolBar/URLInput.vue";
+import SyncButton from "@/components/ToolBar/SyncButton.vue";
+import HistoryControls from "@/components/ToolBar/HistoryControls.vue";
+import InstallUpdateButton from "@/components/ToolBar/InstallUpdateButton.vue";
 import { remote } from "electron";
 import isElectron from "is-electron";
 
@@ -55,7 +57,8 @@ export default {
   components: {
     URLInput,
     HistoryControls,
-    SyncButton
+    SyncButton,
+    InstallUpdateButton
   },
   data() {
     return {


### PR DESCRIPTION
Currently: downloads in background, shows a notification when downloaded ("A new version of Reflex is available. It will be installed the next time you open the app."), notification disappears after a few seconds, which can be difficult to catch what it said and how to update.

New: If update is available, start downloading, display a progress indicator, and when done, turn into a green button. Clicking the button will restart the app with the updated version.

Test:

- Created two beta releases
- Installed first beta release, moved to `/Applications` folder
- App automatically downloaded update (with new UX)
- Manually clicked the install/restart button
- App quit
- App updated and relaunched
- Reflex > About > Version matched the second beta version number