### PR TITLE
Add show/hide artboard feature

### DIFF
--- a/src/renderer/components/Screens/Artboard.vue
+++ b/src/renderer/components/Screens/Artboard.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    v-show="isVisible"
     class="artboard"
     ref="artboard"
     :artboard-id="id"
@@ -55,7 +56,8 @@ export default {
     id: String,
     height: Number,
     width: Number,
-    selectedItems: Array
+    selectedItems: Array,
+    isVisible: Boolean
   },
   data() {
     return {
@@ -118,7 +120,8 @@ export default {
         title: this.title,
         id: this.id,
         width: this.width,
-        height: this.height
+        height: this.height,
+        isVisible: this.isVisible
       });
     },
     // Limits the size of an artboard

--- a/src/renderer/components/Screens/Artboards.vue
+++ b/src/renderer/components/Screens/Artboards.vue
@@ -8,6 +8,7 @@
         :index="index"
         :artboard-id="artboard.id"
         :selectedItems="selectedArtboards"
+        :isVisible="artboard.isVisible"
         ref="artboard"
         class="artboard"
         @resize="resize"

--- a/src/renderer/components/SidePanel/ScreensPanel.vue
+++ b/src/renderer/components/SidePanel/ScreensPanel.vue
@@ -60,7 +60,8 @@ export default {
       this.$store.dispatch("artboards/addArtboard", {
         title: "Untitled",
         width: 375,
-        height: 667
+        height: 667,
+        isVisible: true
       });
     },
     addDefaultSizes() {

--- a/src/renderer/components/SidePanel/artboardEditable.vue
+++ b/src/renderer/components/SidePanel/artboardEditable.vue
@@ -172,7 +172,8 @@ export default {
         title: artboard.title,
         id: artboard.id,
         width: artboard.width,
-        height: artboard.height
+        height: artboard.height,
+        isVisible: artboard.isVisible
       });
     },
     hoverStart(id) {

--- a/src/renderer/mixins/rightClickMenu.js
+++ b/src/renderer/mixins/rightClickMenu.js
@@ -40,6 +40,15 @@ export default function (store, artboard) {
         })
     );
     menu.append(
+      new MenuItem({
+        label: artboard.isVisible ? 'Hide' : 'Show',
+        click() {
+          console.log(artboard)
+          store.commit("artboards/changeArtboardVisibility", artboard);
+        }
+      })
+    );
+    menu.append(
         new MenuItem({
             label: "Open DevTools",
             click() {

--- a/src/renderer/mixins/rightClickMenu.js
+++ b/src/renderer/mixins/rightClickMenu.js
@@ -43,7 +43,6 @@ export default function (store, artboard) {
       new MenuItem({
         label: artboard.isVisible ? 'Hide' : 'Show',
         click() {
-          console.log(artboard)
           store.commit("artboards/changeArtboardVisibility", artboard);
         }
       })

--- a/src/renderer/store/artboards.js
+++ b/src/renderer/store/artboards.js
@@ -55,6 +55,20 @@ export const mutations = {
   },
 
   /**
+   * Change artboard visibility
+   * @param  {} state
+   * @param  {Object} artboard {id}
+   */
+  changeArtboardVisibility(state, artboard) {
+    // 1. Get the artboard.id
+    const id = artboard.id
+    const index = state.list.findIndex(obj => obj.id === id)
+    // 2. Change the visibility of just that artboard's is property
+    state.list[index].isVisible = !artboard.isVisible
+  },
+
+
+  /**
    * Remove an Artboard
    * @param  {} state
    * @param  {} id The ID of the artboard object


### PR DESCRIPTION
This PR addresses issue #161
This feature enables you to hide / show an artboard. You can interface with it by opening the context menu and clicking on the show / hide menu item(changes title based on its current state).

Let me know what you think about this solution.